### PR TITLE
Release 0.6.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-console': 'off',
     'global-require': 'off',
     'space-before-function-paren': ['error', 'always'],
+    'keyword-spacing': 'error',
     'func-names': 'error',
     'prefer-arrow-callback': 'error' ,
     'no-shadow': 'error' ,

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "react-dom": "^15.5.4",
     "react-test-renderer": "^15.5.4",
     "sinon": "^2.1.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recompose-scope",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Compose React HOCs with a scope that restrict the props passing in and out",
   "main": "index.js",
   "scripts": {

--- a/src/__tests__/composeWithScope-spec.js
+++ b/src/__tests__/composeWithScope-spec.js
@@ -103,7 +103,7 @@ describe('composeWithScope', function () {
     const props = { }
     const enhancers = [
       withProps(() => ({ value: 'value' })),
-      exposeProps(['value']),
+      exposeProps('value'),
     ]
 
     const { baseProps } = tester(enhancers, props)
@@ -300,9 +300,14 @@ describe('composeWithScope', function () {
 
     const baseArgs = spyBase.args
 
+    const scopeAt0 = omit('setValue')(spyScope.args[0][0])
+    const scopeAt1 = omit('setValue')(spyScope.args[1][0])
+
     const propsAt0 = omit('setValue')(baseArgs[0][0])
     const propsAt1 = omit('setValue')(baseArgs[1][0])
 
+    deep(scopeAt0, { a, c, d, e, f, value: null })
+    deep(scopeAt1, { a, c, d, e, f, value: 'value' })
     deep(propsAt0, { b, c, d, f, value: null })
     deep(propsAt1, { b, c, d, f, value: 'value' })
   })

--- a/src/consumeProps.js
+++ b/src/consumeProps.js
@@ -9,7 +9,7 @@ import injectOuterProps from './injectOuterProps'
 const consumeProps = arg => {
   const injectEnahncer = injectOuterProps(arg, true)
 
-  if(!isPlainObject(arg)) return injectEnahncer
+  if (!isPlainObject(arg)) return injectEnahncer
   return compose(injectEnahncer, setPropTypes(arg))
 }
 

--- a/src/consumeProps.js
+++ b/src/consumeProps.js
@@ -1,21 +1,13 @@
 import compose from 'recompose/compose'
 import setPropTypes from 'recompose/setPropTypes'
 
-import pick from 'lodash/fp/pick'
-import isArray from 'lodash/fp/isArray'
 import isPlainObject from 'lodash/fp/isPlainObject'
 
 import injectOuterProps from './injectOuterProps'
 
 
-function getMapper (arg) {
-  if (typeof arg === 'function') return arg
-  if (isArray(arg)) return pick(arg)
-  return pick(Object.keys(arg))
-}
-
 const consumeProps = arg => {
-  const injectEnahncer = injectOuterProps(getMapper(arg), true)
+  const injectEnahncer = injectOuterProps(arg, true)
 
   if(!isPlainObject(arg)) return injectEnahncer
   return compose(injectEnahncer, setPropTypes(arg))

--- a/src/enterScope.js
+++ b/src/enterScope.js
@@ -2,22 +2,38 @@ import React from 'react'
 
 import createEagerFactory from 'recompose/createEagerFactory'
 
+import omit from 'lodash/fp/omit'
+import pick from 'lodash/fp/pick'
+
 import { SCOPE, INDEX, scopeContextTypes } from './utils'
 
 
+function toArray (set) {
+  return Array.from(set.values())
+}
 function createScope (props) {
   const consumingKeys = new Set()
   const exposingKeys = new Set()
+
+  let consumeKeys = null
+  let exposeKeys = null
   return {
     outerProps: props,
-    consumingKeys,
-    exposingKeys,
     // bind `add` to owner Set in advance for passing it as callback
     addToConsuming: v => consumingKeys.add(v),
     addToExposing: v => exposingKeys.add(v),
     namespace: null,
+    consume (outerProps) {
+      if (!consumeKeys) consumeKeys = omit(toArray(consumingKeys))
+      return consumeKeys(outerProps)
+    },
+    expose (innerProps) {
+      if (!exposeKeys) exposeKeys = pick(toArray(exposingKeys))
+      return exposeKeys(innerProps)
+    },
   }
 }
+
 
 const enterScope = BaseComponent => {
   const factory = createEagerFactory(BaseComponent)

--- a/src/enterScope.js
+++ b/src/enterScope.js
@@ -20,6 +20,7 @@ function createScope (props) {
   return {
     outerProps: props,
     // bind `add` to owner Set in advance for passing it as callback
+    // `addToConsuming: consumingKeys.add` does not bind add, will cause error
     addToConsuming: v => consumingKeys.add(v),
     addToExposing: v => exposingKeys.add(v),
     namespace: null,
@@ -31,9 +32,9 @@ function createScope (props) {
       if (!exposeKeys) exposeKeys = pick(toArray(exposingKeys))
       return exposeKeys(innerProps)
     },
+    notifyOutBound: null,
   }
 }
-
 
 const enterScope = BaseComponent => {
   const factory = createEagerFactory(BaseComponent)

--- a/src/enterScope.js
+++ b/src/enterScope.js
@@ -23,9 +23,6 @@ const enterScope = BaseComponent => {
   const factory = createEagerFactory(BaseComponent)
 
   class ProvideScope extends React.Component {
-    // TODO constructor() {
-    //   initScope()
-    // }
     constructor (props, context) {
       super(props, context)
 

--- a/src/enterScope.js
+++ b/src/enterScope.js
@@ -27,25 +27,22 @@ const enterScope = BaseComponent => {
       super(props, context)
 
       this.scope = createScope(this.props)
-
-      const index = context[INDEX]
-      this.scopeIndex = (index === undefined) ? 0 : index + 1
     }
     componentWillReceiveProps (nextProps) {
       this.scope.outerProps = nextProps
+      if (this.scope.notifyOutBound) this.scope.notifyOutBound()
     }
     getChildContext () {
+      const index = this.context[INDEX]
+      const scopeIndex = (index === undefined) ? 0 : index + 1
+
       const scopeStack = this.context[SCOPE] || []
-      scopeStack[this.scopeIndex] = this.scope
+      scopeStack[scopeIndex] = this.scope
       return {
         [SCOPE]: scopeStack,
-        [INDEX]: this.scopeIndex,
+        [INDEX]: scopeIndex,
       }
     }
-    // TODO didUpdate, check if props changed and leaveScope not updated
-    // constext.SCOPE[0].forceUpdate leaveScope
-    // maintain currentScopeIndex
-    // willReceiveProps, this.scope.props = nextProps
     render () {
       return factory({ }) // intent to omit all outer props
     }

--- a/src/enterScope.js
+++ b/src/enterScope.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import createEagerFactory from 'recompose/createEagerFactory'
 
-import { SCOPE, scopeContextTypes } from './utils'
+import { SCOPE, INDEX, scopeContextTypes } from './utils'
 
 
 function createScope (props) {
@@ -23,13 +23,32 @@ const enterScope = BaseComponent => {
   const factory = createEagerFactory(BaseComponent)
 
   class ProvideScope extends React.Component {
+    // TODO constructor() {
+    //   initScope()
+    // }
+    constructor (props, context) {
+      super(props, context)
+
+      this.scope = createScope(this.props)
+
+      const index = context[INDEX]
+      this.scopeIndex = (index === undefined) ? 0 : index + 1
+    }
+    componentWillReceiveProps (nextProps) {
+      this.scope.outerProps = nextProps
+    }
     getChildContext () {
-      const scopeStack = this.context[SCOPE]
-      const scope = createScope(this.props)
+      const scopeStack = this.context[SCOPE] || []
+      scopeStack[this.scopeIndex] = this.scope
       return {
-        [SCOPE]: [scope].concat(scopeStack),
+        [SCOPE]: scopeStack,
+        [INDEX]: this.scopeIndex,
       }
     }
+    // TODO didUpdate, check if props changed and leaveScope not updated
+    // constext.SCOPE[0].forceUpdate leaveScope
+    // maintain currentScopeIndex
+    // willReceiveProps, this.scope.props = nextProps
     render () {
       return factory({ }) // intent to omit all outer props
     }

--- a/src/exposeHandlers.js
+++ b/src/exposeHandlers.js
@@ -1,20 +1,31 @@
+import React from 'react'
+
 import createEagerFactory from 'recompose/createEagerFactory'
 import withHandlers from 'recompose/withHandlers'
 
 import { scopeContextTypes, selectScope } from './utils'
 
 
+function getExposeKeys (arg, props) {
+  if (typeof arg === 'function') return Object.keys(arg(props))
+  return Object.keys(arg)
+}
+
 const exposeHandlers = arg => BaseComponent => {
   const WrappedComp = withHandlers(arg)(BaseComponent)
   const factory = createEagerFactory(WrappedComp)
 
-  const Expose = (innerProps, context) => {
-    const handlerCreators = (typeof arg === 'function') ? arg(innerProps) : arg
+  class Expose extends React.Component {
+    constructor (props, context) {
+      super(props, context)
 
-    const { addToExposing } = selectScope(context)
-    Object.keys(handlerCreators).map(addToExposing)
-
-    return factory(innerProps)
+      const { addToExposing } = selectScope(context)
+      const exposeKeys = getExposeKeys(arg, props)
+      exposeKeys.map(addToExposing)
+    }
+    render () {
+      return factory(this.props)
+    }
   }
 
   Expose.contextTypes = scopeContextTypes

--- a/src/exposeNamespace.js
+++ b/src/exposeNamespace.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 import createEagerFactory from 'recompose/createEagerFactory'
 
 import { scopeContextTypes, selectScope } from './utils'
@@ -7,10 +9,16 @@ function exposeProps (ns) {
   return BaseComponent => {
     const factory = createEagerFactory(BaseComponent)
 
-    const Expose = (innerProps, context) => {
-      const scope = selectScope(context)
-      scope.namespace = ns
-      return factory(innerProps)
+    class Expose extends React.Component {
+      constructor (props, context) {
+        super(props, context)
+
+        const scope = selectScope(context)
+        scope.namespace = ns
+      }
+      render () {
+        return factory(this.props)
+      }
     }
 
     Expose.contextTypes = scopeContextTypes

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as composeWithScope } from './composeWithScope'
+export { default as scope } from './composeWithScope'
 export { default as consumeProps } from './consumeProps'
 export { default as injectProps } from './injectProps'
 export { default as exposeProps } from './exposeProps'

--- a/src/injectProps.js
+++ b/src/injectProps.js
@@ -1,21 +1,13 @@
 import compose from 'recompose/compose'
 import setPropTypes from 'recompose/setPropTypes'
 
-import pick from 'lodash/fp/pick'
-import isArray from 'lodash/fp/isArray'
 import isPlainObject from 'lodash/fp/isPlainObject'
 
 import injectOuterProps from './injectOuterProps'
 
 
-function getMapper (arg) {
-  if (typeof arg === 'function') return arg
-  if (isArray(arg)) return pick(arg)
-  return pick(Object.keys(arg))
-}
-
 const injectProps = arg => {
-  const injectEnahncer = injectOuterProps(getMapper(arg))
+  const injectEnahncer = injectOuterProps(arg)
 
   if(!isPlainObject(arg)) return injectEnahncer
   return compose(injectEnahncer, setPropTypes(arg))

--- a/src/injectProps.js
+++ b/src/injectProps.js
@@ -9,7 +9,7 @@ import injectOuterProps from './injectOuterProps'
 const injectProps = arg => {
   const injectEnahncer = injectOuterProps(arg)
 
-  if(!isPlainObject(arg)) return injectEnahncer
+  if (!isPlainObject(arg)) return injectEnahncer
   return compose(injectEnahncer, setPropTypes(arg))
 }
 

--- a/src/leaveScope.js
+++ b/src/leaveScope.js
@@ -15,17 +15,25 @@ const leaveScope = BaseComponent => {
   const factory = createEagerFactory(BaseComponent)
 
   class RemoveScope extends React.Component {
+    constructor (props, context) {
+      super(props, context)
+
+      this.state = {}
+      this.scope = selectScope(context)
+    }
+    componentDidMount () {
+      this.scope.notifyOutBound = () => this.setState({})
+    }
+    componentWillUnmount () {
+      this.scope.notifyOutBound = null
+    }
     getChildContext () {
       const index = this.context[INDEX]
-      const scopeStack = this.context[SCOPE]
       return {
-        [SCOPE]: scopeStack,
+        [SCOPE]: this.context[SCOPE], // could omit
         [INDEX]: (index === 0) ? undefined : index - 1
       }
     }
-    // TODO: didMount put this in context.SCOPE[0]
-    // preserver this.scope
-    // this.setState({ }) to trigger re-render
     render () {
       const {
         consumingKeys,

--- a/src/leaveScope.js
+++ b/src/leaveScope.js
@@ -5,7 +5,7 @@ import createEagerFactory from 'recompose/createEagerFactory'
 import omit from 'lodash/fp/omit'
 import pick from 'lodash/fp/pick'
 
-import { SCOPE, scopeContextTypes, selectScope } from './utils'
+import { SCOPE, INDEX, scopeContextTypes, selectScope } from './utils'
 
 
 function toArray (set) {
@@ -16,11 +16,16 @@ const leaveScope = BaseComponent => {
 
   class RemoveScope extends React.Component {
     getChildContext () {
+      const index = this.context[INDEX]
       const scopeStack = this.context[SCOPE]
       return {
-        [SCOPE]: scopeStack.slice(1),
+        [SCOPE]: scopeStack,
+        [INDEX]: (index === 0) ? undefined : index - 1
       }
     }
+    // TODO: didMount put this in context.SCOPE[0]
+    // preserver this.scope
+    // this.setState({ }) to trigger re-render
     render () {
       const {
         consumingKeys,

--- a/src/leaveScope.js
+++ b/src/leaveScope.js
@@ -2,15 +2,9 @@ import React from 'react'
 
 import createEagerFactory from 'recompose/createEagerFactory'
 
-import omit from 'lodash/fp/omit'
-import pick from 'lodash/fp/pick'
-
 import { SCOPE, INDEX, scopeContextTypes, selectScope } from './utils'
 
 
-function toArray (set) {
-  return Array.from(set.values())
-}
 const leaveScope = BaseComponent => {
   const factory = createEagerFactory(BaseComponent)
 
@@ -35,18 +29,11 @@ const leaveScope = BaseComponent => {
       }
     }
     render () {
-      const {
-        consumingKeys,
-        outerProps,
-        exposingKeys,
-        namespace
-      } = selectScope(this.context)
-
-      const exposingProps = pick(toArray(exposingKeys))(this.props)
+      const { outerProps, consume, expose, namespace } = selectScope(this.context)
 
       return factory({
-        ...omit(toArray(consumingKeys))(outerProps),
-        ...(namespace ? { [namespace]: exposingProps } : exposingProps),
+        ...consume(outerProps),
+        ...(namespace ? { [namespace]: expose(this.props) } : expose(this.props)),
       })
     }
   }

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,0 +1,2 @@
+// alias of composeWithScope
+export default from './composeWithScope'

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,19 @@
 import PropTypes from 'prop-types'
 
-const { array } = PropTypes
+const { array, number } = PropTypes
 
 const SCOPE = 'composeWithScope' // scope key in context
-const scopeContextTypes = { [SCOPE]: array }
+const INDEX = 'composeWithScopeCurrentIndex' // scope key in context
+const scopeContextTypes = { [SCOPE]: array, [INDEX]: number }
 const selectScope = ctx => {
   const scopeStack = ctx[SCOPE]
-  return scopeStack[0]
+  const index = ctx[INDEX]
+  return scopeStack[index]
 }
 
 export {
   SCOPE,
+  INDEX,
   scopeContextTypes,
   selectScope,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 const { array, number } = PropTypes
 
 const SCOPE = 'recompose-scope' // scope key in context
-const INDEX = 'recompose-scope-index' // scope key in context
+const INDEX = 'recompose-scope-index' // scope index key in context
 const scopeContextTypes = { [SCOPE]: array, [INDEX]: number }
 const selectScope = ctx => {
   const scopeStack = ctx[SCOPE]

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types'
 
 const { array, number } = PropTypes
 
-const SCOPE = 'composeWithScope' // scope key in context
-const INDEX = 'composeWithScopeCurrentIndex' // scope key in context
+const SCOPE = 'recompose-scope' // scope key in context
+const INDEX = 'recompose-scope-index' // scope key in context
 const scopeContextTypes = { [SCOPE]: array, [INDEX]: number }
 const selectScope = ctx => {
   const scopeStack = ctx[SCOPE]


### PR DESCRIPTION
- resolve intermediate in scope hoc's `shouldComponentUpdate` return `false`
- only collect consuming keys and exposing keys once in `constructor`
